### PR TITLE
first version of pandoc-theoremnos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build
+dist
+*.egg-info
+demos/out/*
+test/out/*

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+
+pandoc-theoremnos was written by Johannes Schlatow
+<johannes@schlatow.name>
+
+on the basis of the pandoc-*nos filters written and maintained by Thomas J. Duck
+<tomduck@tomduck.ca>.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,3 @@
+pandoc-theoremnos 2.2.1 (2019-10-30)
+
+    * Initial release

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,102 @@
+
+Developer Notes
+===============
+    
+Branches
+--------
+
+The next release is developed in the `nextrelease` branch.  When ready, the changes are merged into the `master` branch.
+
+Demo outputs are stored in the `demos` branch.
+
+
+Install Alternatives
+--------------------
+
+Installing from source may require upgrading `setuptools` by executing
+
+    pip install --upgrade setuptools
+
+as root (or under sudo).
+
+There are a few different options for installing from source:
+    
+1) To install from the github `master` branch use:
+
+       pip install git+https://github.com/tomduck/pandoc-theoremnos.git --user
+
+   (to upgrade append the `--upgrade` flag).
+
+2) To install from the `nextrelease` branch on github, use
+
+       pip install git+https://github.com/tomduck/pandoc-theoremnos.git@nextrelease --user
+
+   (to upgrade use the --upgrade flag).
+
+3) To install from a local source distribution, `cd` into its root
+   and use
+
+       pip install -e . --user
+
+   Note that any changes made to the source will be automatically
+   reflected when the filter is run (which is useful for development).
+
+
+Testing
+-------
+
+Regression tests for pandoc-theoremnos are provided in `test/`.  Read the README.md in that directory for instructions.
+
+
+Preparing a Release
+-------------------
+
+### Merging ####
+
+Merge the `nextrelease` branch into `master` using
+
+    git checkout master
+    git merge nextrelease
+    git push
+
+
+### Updating Demos ###
+
+Starting from the root of the `master` branch, update demos in the `demos` branch using
+
+    cd demos
+    make -B
+    git checkout demos
+    cp -rf out/* ..
+    git commit --amend -am "Updated demos."
+    git push --force
+
+This procedure ensures that there will only be a single revision of each file (see https://stackoverflow.com/a/22827188).
+
+
+### Tagging ###
+
+See https://www.python.org/dev/peps/pep-0440/ for numbering conventions, including for pre-releases.
+
+Check that you are in the `master` branch.
+
+Tagging  (update the version number):
+
+    git tag -a 2.0.0 -m "New release."
+    git push origin 2.0.0
+
+
+### Distributing ###
+
+Create source and binary distributions using
+
+    $ python3 setup.py sdist bdist_wheel
+
+(see https://packaging.python.org/tutorials/packaging-projects/).
+    
+Upload to pypi (update the version number) using
+
+    twine upload dist/pandoc-theoremnos-2.0.0.tar.gz \
+                 dist/pandoc_theoremnos-2.0.0-py3-none-any.whl
+
+(see https://pypi.python.org/pypi/twine).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include DEVELOPERS.md
+include LICENSE
+include ChangeLog
+include AUTHORS

--- a/README.md
+++ b/README.md
@@ -1,1 +1,277 @@
-Under construction.
+
+pandoc-theoremnos 2.2.1
+=====================
+
+*pandoc-theoremnos* is a [pandoc] filter for numbering theorem-like environments and their references when converting markdown to other formats.  It is part of the [pandoc-xnos] filter suite.  LaTeX/pdf, html, and epub output have native support.  Native support for docx output is a work in progress.
+
+Demonstration: Processing [demo.md] with pandoc + pandoc-theoremnos gives numbered theorems and references in [pdf], [tex], [html], [epub] and other formats.
+
+[pandoc-eqnos Issue #18]: https://github.com/tomduck/pandoc-eqnos/issues/18
+[demo.md]: https://raw.githubusercontent.com/tomduck/pandoc-theoremnos/master/demos/demo.md
+[pdf]: https://raw.githack.com/tomduck/pandoc-theoremnos/demos/demo.pdf
+[tex]: https://raw.githack.com/tomduck/pandoc-theoremnos/demos/demo.tex
+[html]: https://raw.githack.com/tomduck/pandoc-theoremnos/demos/demo.html
+[epub]: https://raw.githack.com/tomduck/pandoc-theoremnos/demos/demo.epub
+
+This version of pandoc-theoremnos was tested using pandoc 1.15.2 - 2.7.3,<sup>[1](#footnote1)</sup> and may be used with linux, macOS, and Windows.  Bug reports and feature requests may be posted on the project's [Issues tracker].  If you find pandoc-theoremnos useful, then please kindly give it a star [on GitHub].
+
+See also: [pandoc-fignos], [pandoc-eqnos], [pandoc-secnos], [pandoc-tablenos] \
+Other filters: [pandoc-comments], [pandoc-latex-extensions]
+
+[pandoc]: http://pandoc.org/
+[pandoc-xnos]: https://github.com/tomduck/pandoc-xnos
+[Issues tracker]: https://github.com/tomduck/pandoc-theoremnos/issues
+[on GitHub]: https://github.com/tomduck/pandoc-theoremnos
+[pandoc-fignos]: https://github.com/tomduck/pandoc-fignos
+[pandoc-eqnos]: https://github.com/tomduck/pandoc-eqnos
+[pandoc-secnos]: https://github.com/tomduck/pandoc-secnos
+[pandoc-tablenos]: https://github.com/tomduck/pandoc-tablenos
+[pandoc-comments]: https://github.com/tomduck/pandoc-comments
+[pandoc-latex-extensions]: https://github.com/tomduck/pandoc-latex-extensions
+
+
+Contents
+--------
+
+ 1. [Installation](#installation)
+ 2. [Usage](#usage)
+ 3. [Markdown Syntax](#markdown-syntax)
+ 4. [Customization](#customization)
+ 5. [Technical Details](#technical-details)
+ 6. [Getting Help](#getting-help)
+ 7. [Development](#development)
+ 8. [What's New](#whats-new)
+
+
+Installation
+------------
+
+Pandoc-theoremnos requires [python], a programming language that comes pre-installed on macOS and linux.  It is easily installed on Windows -- see [here](https://realpython.com/installing-python/).  Either python 2.7 or 3.x will do.
+
+Pandoc-theoremnos may be installed using the shell command
+
+    pip install pandoc-theoremnos --user
+
+and upgraded by appending `--upgrade` to the above command.  Pip is a program that downloads and installs software from the Python Package Index, [PyPI].  It normally comes installed with a python distribution.<sup>[2](#footnote2)</sup>
+
+__Pandoc-theoremnos has not (yet) been packaged for pip, please install from source.__
+
+Instructions for installing from source are given in [DEVELOPERS.md].
+
+[python]: https://www.python.org/
+[PyPI]: https://pypi.python.org/pypi
+[DEVELOPERS.md]: DEVELOPERS.md
+
+
+Usage
+-----
+
+Pandoc-theoremnos is activated by using the
+
+    --filter pandoc-theoremnos
+
+option with pandoc.  Alternatively, use
+
+    --filter pandoc-xnos
+
+to activate all of the filters in the [pandoc-xnos] suite (if installed).
+
+Any use of `--filter pandoc-citeproc` or `--bibliography=FILE` should come *after* the `pandoc-theoremnos` or `pandoc-xnos` filter calls.
+
+
+Markdown Syntax
+---------------
+
+The cross-referencing syntax used by pandoc-theoremnos was worked out in [pandoc-eqnos Issue #18].
+As there is no particular theorem markup in markdown, definition lists are used instead.
+
+To mark a definition list as a theorem, definition, lemma, proof, etc., add an id to its attributes:
+
+    [My Theorem]{#thm:id}
+    : This is my theorem.
+
+A prefix such as `#thm:` is required and specifies the type. Types must be defined by [customization](#customization) before being usable. `id` should be replaced with a unique identifier composed of letters, numbers, dashes and underscores.  The term `My Theorem` is the optional name of the theorem.
+
+To reference the theorem, use
+
+    @thm:id
+
+or
+
+    {@thm:id}
+
+Curly braces protect a reference and are stripped from the output.
+
+
+### Clever References ###
+
+Writing markdown like
+
+    See Theorem @thm:id.
+
+seems a bit redundant.  Pandoc-theoremnos supports "clever references" via single-character modifiers in front of a reference.  Users may write
+
+     See +@thm:id.
+
+to have the reference name (i.e., "Theorem") automatically generated.  The above form is used mid-sentence.  At the beginning of a sentence, use
+
+     *@thm:id
+
+instead.  If clever references are enabled by default (see [Customization](#customization), below), then users may disable it for a given reference using<sup>[2](#footnote2)</sup>
+
+    !@thm:id
+
+Note: When using `*thm:id` and emphasis (e.g., `*italics*`) in the same sentence, the `*` in the clever reference must be backslash-escaped; e.g., `\*thm:id`.
+
+
+### Disabling Links ###
+
+To disable a link on a reference, set `nolink=True` in the reference's attributes:
+
+    @thm:id{nolink=True}
+
+
+Customization
+-------------
+
+Pandoc-theoremnos may be customized by setting variables in the [metadata block] or on the command line (using `-M KEY=VAL`).  The following variables are supported:
+
+  * `theoremnos-names` - This is mandatory and specifies the list of
+    theorem-like environments. Every list entry is a map with two entries:
+    `id` specifies the type identifier (e.g. thm) whereas `name` sets
+    the printed name that will be put in front of the number (e.g. Theorem).
+
+  * `theoremnos-warning-level` or `xnos-warning-level` - Set to `0` for
+    no warnings, `1` for critical warnings, or `2` (default) for
+    all warnings.  Warning level 2 should be used when
+    troubleshooting.
+
+  * `theoremnos-cleveref` or just `cleveref` - Set to `True` to assume
+    "+" clever references by default;
+
+  * `xnos-capitalise` - Capitalises the names of "+" references
+    (e.g., change from "table" to "Table");
+
+  * `theoremnos-number-by-section` or `xnos-number-by-section` - Set to
+    `True` to number theorems by section (i.e. Theorem 1.1, 1.2, etc in
+    Section 1, and Theorem 2.1, 2.2, etc in Section 2).  For LaTeX/pdf,
+    html, and epub output, this feature should be used together with
+    pandoc's `--number-sections`
+    [option](https://pandoc.org/MANUAL.html#option--number-sections)
+    enabled.  For docx, use [docx custom styles] instead.
+
+    This option should not be set for numbering by chapter in
+    LaTeX/pdf book document classes.
+
+  * `xnos-number-offset` - Set to an integer to offset the section
+    numbers when numbering tables by section.  For html and epub
+    output, this feature should be used together with pandoc's
+    `--number-offset`
+    [option](https://pandoc.org/MANUAL.html#option--number-sections)
+    set to the same integer value.  For LaTeX/PDF, this option
+    offsets the actual section numbers as required.
+
+  * `theoremnos-shared-counter` - Set to 'True' if all theorem
+    type shall share the same counter (i.e. Definition 1, Theorem 2)
+    instead of counting separately for every type.
+
+Note that variables beginning with `theoremnos-` apply to only pandoc-theoremnos, whereas variables beginning with `xnos-` apply to all of the pandoc-fignos/eqnos/tablenos/secnos/theremnos.
+
+[metadata block]: http://pandoc.org/README.html#extension-yaml_metadata_block
+[docx custom styles]: https://pandoc.org/MANUAL.html#custom-styles
+
+
+Technical Details
+-----------------
+
+### TeX/pdf Output ###
+
+During processing, pandoc-theoremnos inserts packages and supporting TeX into the `header-includes` metadata field.  To see what is inserted, set the `theoremnos-warning-level` meta variable to `2`.  Note that any use of pandoc's `--include-in-header` option [overrides](https://github.com/jgm/pandoc/issues/3139) all `header-includes`.
+
+An example reference in TeX looks like
+
+~~~latex
+See \cref{thm:1}.
+~~~
+
+For every entry in the `theoremnos-names` meta variable, a theorem type will be defined like
+
+~~~latex
+\newtheorem{thm}{Theorem}
+~~~
+
+An example theorem looks like
+
+~~~latex
+\begin{thm}[My Theorem]
+  \label{th:1}
+  This is my theorem.
+\end{thm}
+~~~
+
+Other details:
+
+  * The `cleveref` and `caption` packages are used for clever
+    references and caption control, respectively; 
+  * The `\label` and `\ref` macros are used for table labels and
+    references, respectively (`\Cref` and `\cref` are used for
+    clever references);
+  * Clever reference names are set with `\Crefname` and `\crefname`;
+
+
+### Other Output Formats ###
+
+An example reference in html looks like
+
+~~~html
+See theorem <a href="#thm:1">1</a>.
+~~~
+
+An example theorem looks like
+
+~~~html
+<dl id="thm:1" class="theoremnos">
+  <dt>Theorem 1 (My Theorem):</dt>
+  <dd>
+     This is my theorem.
+  </dd>
+</dl>
+~~~
+
+
+### Docx Output ###
+
+Docx OOXML output is under development and subject to change.  Native capabilities will be used wherever possible.
+
+
+Getting Help
+------------
+
+If you have any difficulties with pandoc-theoremnos, or would like to see a new feature, then please submit a report to our [Issues tracker].
+
+
+Development
+-----------
+
+Pandoc-theoremnos will continue to support pandoc 1.15-onward and python 2 & 3 for the foreseeable future.  The reasons for this are that a) some users cannot upgrade pandoc and/or python; and b) supporting all versions tends to make pandoc-theoremnos more robust.
+
+Developer notes are maintained in [DEVELOPERS.md].
+
+
+What's New
+----------
+
+New in 2.2.1: Pandoc-theoremnos is a new filter. It has been marked with version number 2.2.1 in keeping with the major version number of the underlying pandoc-xnos library.
+
+
+----
+
+**Footnotes**
+
+<a name="footnote1">1</a>: Pandoc 2.4 [broke](https://github.com/jgm/pandoc/issues/5099) how references are parsed, and so is not supported.
+
+<a name="footnote2">2</a>: Anaconda users may be tempted to use `conda` instead.  This is not advised.  The packages distributed on the Anaconda cloud are unofficial, are not posted by me, and in some cases are ancient.  Some tips on using `pip` in a `conda` environment may be found [here](https://www.anaconda.com/using-pip-in-a-conda-environment/).
+
+<a name="footnote3">3</a>: The disabling modifier "!" is used instead of "-" because [pandoc unnecessarily drops minus signs] in front of references.
+
+[pandoc unnecessarily drops minus signs]: https://github.com/jgm/pandoc/issues/2901

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,0 +1,41 @@
+
+extensions = .pdf .html .epub .tex
+
+dest = $(addprefix out/demo,$(extensions))
+
+
+all: $(dest) 
+
+
+$(filter out/demo.%,$(dest)): demo.md
+
+
+out/%.pdf: %.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	pandoc $< --filter pandoc-theoremnos --variable urlcolor=blue -o $@
+
+out/%.html: %.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	pandoc $< --standalone --filter pandoc-theoremnos --include-in-header=headers/header.html -o $@
+
+out/%.epub: %.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	pandoc $< -t epub3 --filter pandoc-theoremnos --include-in-header=headers/header.epub -o $@
+
+out/%:
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	pandoc $^ --filter pandoc-theoremnos -o $@
+
+
+restore: clean
+	for num in "" ; do \
+      for ext in $(extensions) ; do \
+        git checkout out/demo$$num$$ext ; \
+      done ; \
+    done
+
+
+.PHONY: clean
+
+clean:
+	rm -rf out

--- a/demos/demo.md
+++ b/demos/demo.md
@@ -1,0 +1,31 @@
+---
+title: Pandoc-theoremnos Demo
+theoremnos-cleveref: True
+theoremnos-names:
+- id: thm
+  name: Theorem
+- id: dfn
+  name: Definition
+...
+
+[]{#dfn:good}
+: This is my definition of good.
+
+[Pythagorean theorem]{#thm:pythagorean}
+
+: For a right triangle, if $c$ denotes the length of the hypotenuse
+and $a$ and $b$ denote the lengths of the other two sides, we have
+
+$$a^2 + b^2 = c^2$$
+
+
+*@thm:pythagorean is very popular and is unrelated to @dfn:good.
+
+
+And this is a normal definition list:
+
+Day
+: When the sun is above the horizon.
+
+Night
+: When it is not day.

--- a/demos/headers/header.epub
+++ b/demos/headers/header.epub
@@ -1,0 +1,3 @@
+<style>
+dl.theoremnos dt {font-weight:bold;}
+</style>

--- a/demos/headers/header.html
+++ b/demos/headers/header.html
@@ -1,0 +1,4 @@
+<style>
+html {margin: 0 auto; max-width: 5in;}
+dl.theoremnos dt {font-weight:bold;}
+</style>

--- a/pandoc_theoremnos.py
+++ b/pandoc_theoremnos.py
@@ -1,0 +1,511 @@
+#! /usr/bin/env python
+
+"""pandoc-theoremnos: a pandoc filter that inserts theorem nos. and refs."""
+
+
+__version__ = '2.2.1'
+
+
+# Copyright 2015-2019 Thomas J. Duck. Johannes Schlatow
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# OVERVIEW
+#
+# The basic idea is to scan the document twice in order to:
+#
+#   1. Insert text for the theorem number in each theorem.
+#      For LaTeX, change to a numbered theorem and use \label{...}
+#      instead.  The theorem labels and associated theorem numbers
+#      are stored in the global references tracker.
+#
+#   2. Replace each reference with an theorem number.  For LaTeX,
+#      replace with \ref{...} instead.
+#
+# This is followed by injecting header code as needed for certain output
+# formats.
+
+# pylint: disable=invalid-name
+
+import re
+import functools
+import argparse
+import json
+import copy
+import textwrap
+import uuid
+
+from pandocfilters import walk
+from pandocfilters import DefinitionList, Div, Plain, RawBlock, RawInline, Str, Span, stringify
+
+import pandocxnos
+from pandocxnos import PandocAttributes
+from pandocxnos import STRTYPES, STDIN, STDOUT, STDERR
+from pandocxnos import check_bool, get_meta
+from pandocxnos import repair_refs, process_refs_factory, replace_refs_factory
+from pandocxnos import attach_attrs_factory, detach_attrs_factory
+from pandocxnos import insert_secnos_factory, delete_secnos_factory
+from pandocxnos import elt
+
+
+# Patterns for matching labels and references
+LABEL_PATTERN = None
+
+# Meta variables; may be reset elsewhere
+cleveref = False    # Flags that clever references should be used
+capitalise = False  # Flags that plusname should be capitalised
+names = dict()      # Stores names and types of theorems
+warninglevel = 2        # 0 - no warnings; 1 - some warnings; 2 - all warnings
+numbersections = False  # Flags that theorems should be numbered by section
+secoffset = 0
+sharedcounter = False
+
+# Processing state variables
+cursec = None    # Current section
+Nreferences = dict()  # Number of references in current section (or document)
+references = {}  # Maps reference labels to [number/tag, theorem secno]
+
+PANDOCVERSION = None
+
+# Actions --------------------------------------------------------------------
+
+
+# pylint: disable=too-many-branches
+def _process_theorem(value, fmt):
+    """Processes the theorem.  Returns a dict containing theorem properties."""
+
+    # pylint: disable=global-statement
+    global Nreferences  # Global references counter
+    global cursec       # Current section
+
+    # Initialize the return value
+    thm = {'is_unnumbered': False,
+           'is_unreferenceable': False,
+           'is_tagged': False}
+
+    # Parse the theorem attributes
+    attrs = thm['attrs'] = PandocAttributes(value[0], 'pandoc')
+
+    # Bail out if the label does not conform to expectations
+    if not LABEL_PATTERN or not LABEL_PATTERN.match(attrs.id):
+        assert False, "%s" % LABEL_PATTERN
+        thm.update({'is_unnumbered':True, 'is_unreferenceable':True})
+        return thm
+
+    # Identify unreferenceable theorems
+    if attrs.id[-1] == ':': # Make up a unique description
+        attrs.id += str(uuid.uuid4())
+        thm['is_unreferenceable'] = True
+
+    counter = attrs.id.split(':')[0]
+    if sharedcounter:
+       counter = 'shared'
+
+    # Update the current section number
+    if attrs['secno'] != cursec:  # The section number changed
+        cursec = attrs['secno']   # Update the global section tracker
+        for key, nref in Nreferences.items():
+            Nreferences[key] = 1           # Resets the global reference counter
+
+    # Pandoc's --number-sections supports section numbering latex/pdf, html,
+    # epub, and docx
+    if numbersections:
+        # Latex/pdf supports theorems numbers by section natively.  For the
+        # other formats we must hard-code in theorem numbers by section as
+        # tags.
+        if fmt in ['html', 'html5', 'epub', 'epub2', 'epub3', 'docx'] and \
+          'tag' not in attrs:
+            attrs['tag'] = str(cursec+secoffset) + '.' + str(Nreferences[counter])
+            Nreferences[counter] += 1
+
+    # Save reference information
+    thm['is_tagged'] = 'tag' in attrs
+    if thm['is_tagged']:   # ... then save the tag
+        # Remove any surrounding quotes
+        if attrs['tag'][0] == '"' and attrs['tag'][-1] == '"':
+            attrs['tag'] = attrs['tag'].strip('"')
+        elif attrs['tag'][0] == "'" and attrs['tag'][-1] == "'":
+            attrs['tag'] = attrs['tag'].strip("'")
+        references[attrs.id] = [attrs['tag'], cursec]
+    else:
+        references[attrs.id] = [Nreferences[counter], cursec]
+        Nreferences[counter] += 1  # Increment the global reference counter
+
+    return thm
+
+
+def _adjust_theorem(fmt, thm, value):
+    """Adjusts the theorem depending on the output format."""
+    attrs = thm['attrs']
+    if thm['is_unnumbered']:  # Unnumbered is also unreferenceable
+        pass
+    elif fmt in ['latex', 'beamer']:
+        pass  # Insert tex in _add_markup() instead
+    elif fmt in ('html', 'html5', 'epub', 'epub2', 'epub3'):
+        pass  # Insert html in _add_markup() instead
+
+
+def _add_markup(fmt, thm, value):
+    """Adds markup to the output."""
+
+    attrs = thm['attrs']
+    ret = None
+
+    if thm['is_unnumbered']:  # Unnumbered is also unreferenceable
+        assert False, "is unnumbered"
+        ret = None
+    elif fmt in ['latex', 'beamer']:
+        # remark: tagged theorems are not (yet) supported
+
+        # Present theorem as a definition list
+        env   = attrs.id.split(':')[0]
+
+        tmp = value[0][0]['c'][1]
+        title = ''
+        if len(tmp) >= 1:
+            title = '[%s]' % stringify(tmp)
+
+        start = RawBlock('tex',
+                          r'\begin{%s}%s%s' % \
+                            (env, title,
+                            '' if thm['is_unreferenceable'] else
+                             '\label{%s} '%attrs.id))
+        endtags = RawBlock('tex',
+                           r'\end{%s}' % env)
+        content = value[1][0]
+        ret = [start]+content+[endtags]
+
+    elif fmt in ('html', 'html5', 'epub', 'epub2', 'epub3'):
+
+        if isinstance(references[attrs.id][0], int):  # Numbered reference
+            num = Str(' %d'%references[attrs.id][0])
+        else:  # Tagged reference
+            assert isinstance(references[attrs.id][0], STRTYPES)
+            text = ' ' + references[attrs.id][0]
+            if text.startswith('$') and text.endswith('$'):
+                math = text.replace(' ', r'\ ')[1:-1]
+                num = Math({"t":"InlineMath", "c":[]}, math)
+            else:  # Text
+                num = Str(text)
+
+        # Present theorem as a definition list
+        outer = RawBlock('html',
+                          '<dl%sclass="theoremnos">' % \
+                            (' ' if thm['is_unreferenceable'] else
+                             ' id="%s" '%attrs.id))
+        name = names[attrs.id.split(':')[0]]
+        head = RawBlock('html', '<dt>')
+        endhead = RawBlock('html', '</dt><dd>')
+        title = value[0][0]['c'][1]
+        if len(title) >= 1:
+            title.insert(0, Str(' ('))
+            title.insert(0, num)
+            title.append(Str(')'))
+        else:
+            title.append(num)
+
+        title.insert(0, Str('%s' % name))
+        title.append(Str(':'))
+        content = value[1][0]
+        endtags = RawBlock('html', '</dd></dl>')
+        ret = [outer,head,Plain(title),endhead]+content+[endtags]
+
+    return ret
+
+
+def process_theorems(key, value, fmt, meta):  # pylint: disable=unused-argument
+    """Processes the attributed definition lists."""
+
+    # Process definition lists and add markup
+    if key == 'DefinitionList':
+        markup = []
+        for val in value: # iterate entries
+            if val[0][0]['t'] != 'Span':
+                # skip if it is a normal definition list
+                return None
+
+            thm = _process_theorem(val[0][0]['c'], fmt)
+            assert thm['attrs'].id
+
+            _adjust_theorem(fmt, thm, val)
+            markup = markup + _add_markup(fmt, thm, val)
+
+        return Div(['',[],[]], markup)
+
+    return None
+
+
+# TeX blocks -----------------------------------------------------------------
+
+# Section number offset
+SECOFFSET_TEX = r"""
+%% pandoc-theoremnos: section number offset
+\setcounter{section}{%s}
+"""
+
+
+# Html blocks ----------------------------------------------------------------
+
+
+# Main program ---------------------------------------------------------------
+
+# pylint: disable=too-many-statements
+def process(meta):
+    """Saves metadata fields in global variables and returns a few
+    computed fields."""
+
+    # pylint: disable=global-statement
+    global cleveref    # Flags that clever references should be used
+    global capitalise  # Flags that plusname should be capitalised
+    global names       # Sets theorem types and names
+    global warninglevel    # 0 - no warnings; 1 - some; 2 - all
+    global LABEL_PATTERN
+    global numbersections
+    global secoffset
+    global sharedcounter
+
+    # Read in the metadata fields and do some checking
+
+    for name in ['theoremnos-warning-level', 'xnos-warning-level']:
+        if name in meta:
+            warninglevel = int(get_meta(meta, name))
+            pandocxnos.set_warning_level(warninglevel)
+            break
+
+    metanames = ['theoremnos-warning-level', 'xnos-warning-level',
+                 'theoremnos-cleveref', 'xnos-cleveref',
+                 'xnos-capitalise', 'xnos-capitalize',
+                 'xnos-caption-separator', # Used by pandoc-fignos/tablenos
+                 'theoremnos-names',
+                 'xnos-number-by-section',
+                 'theoremnos-shared-counter',
+                 'theoremnos-number-by-section',
+                 'xnos-number-offset' ]
+
+    if warninglevel:
+        for name in meta:
+            if (name.startswith('theoremnos') or name.startswith('xnos')) and \
+              name not in metanames:
+                msg = textwrap.dedent("""
+                          pandoc-theoremnos: unknown meta variable "%s"\n
+                      """ % name)
+                STDERR.write(msg)
+
+    for name in ['theoremnos-cleveref', 'xnos-cleveref']:
+        # 'xnos-cleveref' enables cleveref in all 3 of fignos/eqnos/tablenos
+        if name in meta:
+            cleveref = check_bool(get_meta(meta, name))
+            break
+
+    for name in ['xnos-capitalise', 'xnos-capitalize']:
+        # 'xnos-capitalise' enables capitalise in all 4 of
+        # fignos/eqnos/tablenos/theoremonos.  Since this uses an option in 
+        # the caption package, it is not possible to select between the four.
+        # 'xnos-capitalize' is an alternative spelling
+        if name in meta:
+            capitalise = check_bool(get_meta(meta, name))
+            break
+
+    for name in ['theoremnos-number-by-section', 'xnos-number-by-section']:
+        if name in meta:
+            numbersections = check_bool(get_meta(meta, name))
+            break
+
+    if 'xnos-number-offset' in meta:
+        secoffset = int(get_meta(meta, 'xnos-number-offset'))
+
+    if 'theoremnos-shared-counter' in meta:
+        sharedcounter = check_bool(get_meta(meta, 'theoremnos-shared-counter'))
+
+    if 'theoremnos-names' in meta:
+        # TODO move this into get_meta of pandoc-xnos
+        assert meta['theoremnos-names']['t'] == 'MetaList'
+        tmp = []
+        for data in meta['theoremnos-names']['c']:
+            assert data['t'] == 'MetaMap'
+            entry = dict()
+            for key in data['c']:
+                entry[key] = stringify(data['c'][key])
+            tmp.append(entry)
+
+        for entry in tmp:
+            assert isinstance(entry, dict), "%s is of type %s" % (entry, type(entry))
+            assert 'id' in entry and isinstance(entry['id'], STRTYPES)
+            assert 'name' in entry and isinstance(entry['name'], STRTYPES)
+            names[entry['id']] = entry['name']
+            Nreferences[entry['id']] = 0
+
+        Nreferences['shared'] = 0
+
+    if len(names):
+        LABEL_PATTERN = re.compile("(%s):%s" % ('|'.join(names.keys()), r'[\w/-]*'))
+
+
+def add_tex(meta):
+    """Adds tex to the meta data."""
+
+    warnings = warninglevel == 2 and references and \
+      (pandocxnos.cleveref_required() or len(names) or secoffset or numbersections)
+    if warnings:
+        msg = textwrap.dedent("""\
+                  pandoc-theoremnos: Wrote the following blocks to
+                  header-includes.  If you use pandoc's
+                  --include-in-header option then you will need to
+                  manually include these yourself.
+              """)
+        STDERR.write('\n')
+        STDERR.write(textwrap.fill(msg))
+        STDERR.write('\n')
+
+    # Update the header-includes metadata.  Pandoc's
+    # --include-in-header option will override anything we do here.  This
+    # is a known issue and is owing to a design decision in pandoc.
+    # See https://github.com/jgm/pandoc/issues/3139.
+
+    if pandocxnos.cleveref_required() and references:
+        tex = """
+            %%%% pandoc-theoremnos: required package
+            \\usepackage{amsthm}
+            \\usepackage%s{cleveref}
+        """ % ('[capitalise]' if capitalise else '')
+        pandocxnos.add_to_header_includes(
+            meta, 'tex', tex,
+            regex=r'\\usepackage(\[[\w\s,]*\])?\{cleveref\}')
+
+    if secoffset and references:
+        pandocxnos.add_to_header_includes(
+            meta, 'tex', SECOFFSET_TEX % secoffset,
+                        regex=r'\\setcounter\{section\}')
+
+    if len(names):
+        tex = """
+            %%%% pandoc-theoremnos: set theorem types
+            """
+        firstid = None
+        for thid,thname in names.items():
+            tex +=  """\\newtheorem{%s}%s{%s}%s
+            """ % (thid, '[%s]' % firstid if firstid is not None else '',
+                   thname, '[section]' if numbersections and firstid is None else '')
+
+            if sharedcounter and firstid is None:
+                firstid = thid
+
+        pandocxnos.add_to_header_includes(meta, 'tex', tex)
+
+    if warnings:
+        STDERR.write('\n')
+
+def add_html(meta):
+    return
+
+# pylint: disable=too-many-locals, unused-argument
+def main(stdin=STDIN, stdout=STDOUT, stderr=STDERR):
+    """Filters the document AST."""
+
+    # pylint: disable=global-statement
+    global PANDOCVERSION
+
+    # Read the command-line arguments
+    parser = argparse.ArgumentParser(\
+      description='Pandoc theorem numbers filter.')
+    parser.add_argument(\
+      '--version', action='version',
+      version='%(prog)s {version}'.format(version=__version__))
+    parser.add_argument('fmt')
+    parser.add_argument('--pandocversion', help='The pandoc version.')
+    args = parser.parse_args()
+
+    # Get the output format and document
+    fmt = args.fmt
+    doc = json.loads(stdin.read())
+
+    # Initialize pandocxnos
+    PANDOCVERSION = pandocxnos.init(args.pandocversion, doc)
+
+    # Chop up the doc
+    meta = doc['meta'] if PANDOCVERSION >= '1.18' else doc[0]['unMeta']
+    blocks = doc['blocks'] if PANDOCVERSION >= '1.18' else doc[1:]
+
+    # Process the metadata variables
+    process(meta)
+
+    if LABEL_PATTERN:
+        # First pass
+        insert_secnos = insert_secnos_factory(Span)
+        delete_secnos = delete_secnos_factory(Span)
+        altered = functools.reduce(lambda x, action: walk(x, action, fmt, meta),
+                                   [insert_secnos, process_theorems, delete_secnos], blocks)
+
+        # Second pass
+        if fmt in ('latex', 'beamer'):
+            process_refs = process_refs_factory('pandoc-theoremnos', LABEL_PATTERN,
+                                                references.keys())
+
+            # latex takes care of inserting the correct plusname/starname
+            replace_refs = replace_refs_factory(references,
+                                                cleveref, False,
+                                                ['UNUSED'],
+                                                ['UNUSED'])
+
+            process_all_refs = [process_refs, replace_refs]
+
+        else:
+            # replace each theorem type separately (to insert the correct names)
+            process_all_refs = []
+
+            for thid, thname in names.items():
+                refs = dict()
+                for key, value in references.items():
+                    if key.split(':')[0] == thid:
+                        refs[key] = value
+                if len(refs):
+
+                    PATTERN = re.compile("%s:%s" % (thid, r'[\w/-]*'))
+                    process_refs = process_refs_factory('pandoc-theoremnos', PATTERN,
+                                                        refs.keys())
+                    replace_refs = replace_refs_factory(refs,
+                                                        cleveref, False,
+                                                        [thname],
+                                                        [thname])
+
+                    process_all_refs.append(process_refs)
+                    process_all_refs.append(replace_refs)
+
+        attach_attrs_span = attach_attrs_factory('pandoc-theoremnos', Span,
+                                                 replace=True)
+        altered = functools.reduce(lambda x, action: walk(x, action, fmt, meta),
+                                   [repair_refs] + process_all_refs +
+                                   [attach_attrs_span],
+                                   altered)
+
+        if fmt in ['latex', 'beamer']:
+            add_tex(meta)
+        elif fmt in ['html', 'html5', 'epub', 'epub2', 'epub3']:
+            add_html(meta)
+
+        # Update the doc
+        if PANDOCVERSION >= '1.18':
+            doc['blocks'] = altered
+        else:
+            doc = doc[:1] + altered
+
+    # Dump the results
+    json.dump(doc, stdout)
+
+    # Flush stdout
+    stdout.flush()
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,60 @@
+"""setup.py - install script for pandoc-theoremnos."""
+
+# Copyright 2015-2019 Thomas J. Duck, Johannes Schlatow.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import io
+
+from setuptools import setup
+
+DESCRIPTION = """\
+A pandoc filter for numbering tables and their references
+when converting markdown to other formats.
+"""
+
+# From https://stackoverflow.com/a/39671214
+__version__ = re.search(
+    r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+    io.open('pandoc_theoremnos.py', encoding='utf_8_sig').read()
+    ).group(1)
+
+setup(
+    name='pandoc-theoremnos',
+    version=__version__,
+
+    author='Thomas J. Duck',
+    author_email='tomduck@tomduck.ca',
+    description='Theorem number filter for pandoc',
+    long_description=DESCRIPTION,
+    license='GPL',
+    keywords='pandoc table numbers filter',
+    url='https://github.com/tomduck/pandoc-theoremnos',
+    download_url='https://github.com/tomduck/pandoc-theoremnos/tarball/' + \
+                 __version__,
+
+    install_requires=['pandoc-xnos~=2.2.1'],
+
+    py_modules=['pandoc_theoremnos'],
+    entry_points={'console_scripts':['pandoc-theoremnos = pandoc_theoremnos:main']},
+
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: End Users/Desktop',
+        'Environment :: Console',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python'
+        ],
+)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,82 @@
+
+# Note: pandoc-2.4 broke citation parsing, and so is not supported.
+
+v2.7 = 2.7.3
+v2.6 = 2.6
+v2.5 = 2.5
+v2.3 = 2.3.1
+v2.2 = 2.2.3.2
+v2.1 = 2.1.3
+v2.0 = 2.0.6
+v1.19 = 1.19.2
+v1.18 = 1.18
+v1.17 = 1.17.2
+v1.16 = 1.16.0.2
+v1.15 = 1.15.2
+
+PANDOC-2.7 = pandoc-$(v2.7)
+PANDOC-2.6 = pandoc-$(v2.6)
+PANDOC-2.5 = pandoc-$(v2.5)
+PANDOC-2.3 = pandoc-$(v2.3)
+PANDOC-2.2 = pandoc-$(v2.2)
+PANDOC-2.1 = pandoc-$(v2.1)
+PANDOC-2.0 = pandoc-$(v2.0)
+PANDOC-1.19 = pandoc-$(v1.19)
+PANDOC-1.18 = pandoc-$(v1.18)
+PANDOC-1.17 = pandoc-$(v1.17)
+PANDOC-1.16 = pandoc-$(v1.16)
+PANDOC-1.15 = pandoc-$(v1.15)
+
+PYTHON-2.7 = python2.7
+
+PDFFLAGS = --variable geometry:margin=1in --standalone --variable urlcolor=blue
+HTMLFLAGS = --standalone --variable urlcolor=blue
+
+
+all: pdf html epub docx
+
+pdf: out/test-2.7.pdf \
+     out/test-2.7-py2.7.pdf \
+     out/test-2.6.pdf \
+     out/test-2.5.pdf \
+     out/test-2.3.pdf \
+     out/test-2.2.pdf \
+     out/test-2.1.pdf \
+     out/test-2.0.pdf \
+     out/test-1.19.pdf \
+     out/test-1.18.pdf \
+     out/test-1.17.pdf \
+     out/test-1.16.pdf \
+     out/test-1.15.pdf
+
+html: out/test-2.7.html
+
+epub: out/test-2.7.epub
+
+docx: out/test-2.7.docx
+
+
+out/test-%.html: test.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	$(PANDOC-$*) $< --filter pandoc-theoremnos $(HTMLFLAGS) -o $@
+
+out/test-%-py2.7.pdf: test.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	$(PANDOC-$*) $< -t json -M xnos-warning-level=0 | $(PYTHON-2.7) ../pandoc_theoremnos.py latex --pandocversion=$(v$*) | $(PANDOC-$*) -f json $(PDFFLAGS) -o $@
+
+out/test-%.pdf: test.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	$(PANDOC-$*) $< --filter pandoc-theoremnos $(PDFFLAGS) -o $@
+
+out/test-%.epub: test.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	$(PANDOC-$*) $< --filter pandoc-theoremnos -o $@
+
+out/test-%.docx: test.md
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	$(PANDOC-$*) $< --filter pandoc-theoremnos -o $@
+
+.PHONY: clean
+
+clean:
+	rm -rf out

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,5 @@
+
+Regression Tests
+================
+
+This directory contains regression tests.  Running `make` produces out/test-* files that may be inspected and compared.  Note that the Makefile expects specific numbered pandoc executables (e.g., pandoc-2.7.3) to be available.  You will need to adapt the Makefile to use what is available on your system.

--- a/test/cleveref.tex
+++ b/test/cleveref.tex
@@ -1,0 +1,1 @@
+\usepackage{cleveref}

--- a/test/test.md
+++ b/test/test.md
@@ -1,0 +1,31 @@
+---
+title: Pandoc-theoremnos Demo
+theoremnos-cleveref: True
+theoremnos-names:
+- id: thm
+  name: Theorem
+- id: dfn
+  name: Definition
+...
+
+[]{#dfn:good}
+: This is my definition of good.
+
+[Pythagorean theorem]{#thm:pythagorean}
+
+: For a right triangle, if $c$ denotes the length of the hypotenuse
+and $a$ and $b$ denote the lengths of the other two sides, we have
+
+$$a^2 + b^2 = c^2$$
+
+
+*@thm:pythagorean is very popular and is unrelated to @dfn:good.
+
+
+And this is a normal definition list:
+
+Day
+: When the sun is above the horizon.
+
+Night
+: When it is not day.


### PR DESCRIPTION
Please note, that this requires a slight modification of pandoc-xnos (see [PR#10](https://github.com/tomduck/pandoc-xnos/pull/10)).

Furthermore, the `get_meta` function of pandoc-xnos does not (yet?) support MetaLists of MetaMaps. Hence, pandoc-theoremnos does not use `get_meta` for processing the meta map `theoremnos-names` (see TODO comment in the code).