### PR TITLE
changed requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     download_url='https://github.com/tomduck/pandoc-theoremnos/tarball/' + \
                  __version__,
 
-    install_requires=['pandoc-xnos~=2.3.0, < 3.0'],
+    install_requires=['pandoc-xnos~=2.5.0, < 3.0'],
 
     py_modules=['pandoc_theoremnos'],
     entry_points={'console_scripts':['pandoc-theoremnos = pandoc_theoremnos:main']},


### PR DESCRIPTION
I had an error where pandoc-theoremnos would fail when processing a markdown table. This error seems to be fixed with pandoc-xnos version 2.5. 

I updated the requirements to fix this issue.